### PR TITLE
Added user-id into the messages.log

### DIFF
--- a/jasmin/protocols/smpp/operations.py
+++ b/jasmin/protocols/smpp/operations.py
@@ -6,8 +6,7 @@ from jasmin.vendor.smpp.pdu.operations import SubmitSM, DataSM
 from jasmin.protocols.smpp.configs import SMPPClientConfig
 from jasmin.vendor.smpp.pdu.pdu_types import (EsmClass, EsmClassMode, 
                                             EsmClassType, EsmClassGsmFeatures, 
-                                            MoreMessagesToSend, MessageState,
-                                            EsmClass, EsmClassMode, EsmClassType)
+                                            MoreMessagesToSend, MessageState)
 
 class UnknownMessageStatusError(Exception):
     """Raised when message_status is not recognized


### PR DESCRIPTION
Hello, Fourat!

user-id is good to see in the messages.log, so I am proposing this commit. Also replaced submit_sm_resp_bill.user.uid with the userid local variable, because I made it to be used anyway for printing in log

Also, have discovered and removed some doubling imports in jasmin/protocols/smpp/operations.py

