### PR TITLE
Added user-id into the messages.log

### DIFF
--- a/jasmin/managers/listeners.py
+++ b/jasmin/managers/listeners.py
@@ -187,6 +187,7 @@ class SMPPClientSMListener:
             submit_sm_resp_bill = None
         else:  
             submit_sm_resp_bill = pickle.loads(amqpMessage.content.properties['headers']['submit_sm_resp_bill'])
+            userid = submit_sm_resp_bill.user.uid
         
         if r.response.status == CommandStatus.ESME_ROK:
             # Get bill information
@@ -230,9 +231,10 @@ class SMPPClientSMListener:
             else:
                 short_message = r.request.params['short_message']
             
-            self.log.info("SMS-MT [cid:%s] [queue-msgid:%s] [smpp-msgid:%s] [status:%s] [prio:%s] [dlr:%s] [validity:%s] [from:%s] [to:%s] [content:%s]" % 
+            self.log.info("SMS-MT [cid:%s] [user-id:%s] [queue-msgid:%s] [smpp-msgid:%s] [status:%s] [prio:%s] [dlr:%s] [validity:%s] [from:%s] [to:%s] [content:%s]" % 
                           (
                            self.SMPPClientFactory.config.id,
+                           userid,
                            msgid,
                            r.response.params['message_id'],
                            r.response.status,
@@ -246,9 +248,10 @@ class SMPPClientSMListener:
                            short_message
                            ))
         else:
-            self.log.info("SMS-MT [cid:%s] [queue-msgid:%s] [status:ERROR/%s] [prio:%s] [dlr:%s] [validity:%s] [from:%s] [to:%s] [content:%s]" % 
+            self.log.info("SMS-MT [cid:%s] [user-id:%s] [queue-msgid:%s] [status:ERROR/%s] [prio:%s] [dlr:%s] [validity:%s] [from:%s] [to:%s] [content:%s]" % 
                           (
                            self.SMPPClientFactory.config.id,
+                           userid,
                            msgid,
                            r.response.status,
                            amqpMessage.content.properties['priority'],
@@ -383,7 +386,7 @@ class SMPPClientSMListener:
         # Bill will be charged by bill_request.submit_sm_resp.UID queue consumer
         if total_bill_amount > 0:
             pubQueueName = 'bill_request.submit_sm_resp.%s' % submit_sm_resp_bill.user.uid
-            content = SubmitSmRespBillContent(submit_sm_resp_bill.bid, submit_sm_resp_bill.user.uid, total_bill_amount)
+            content = SubmitSmRespBillContent(submit_sm_resp_bill.bid, userid, total_bill_amount)
             self.log.debug("Requesting a SubmitSmRespBillContent from a bill [bid:%s] with routing_key[%s]: %s" % 
                            (submit_sm_resp_bill.bid, pubQueueName, total_bill_amount))
             yield self.amqpBroker.publish(exchange='billing', 

--- a/jasmin/protocols/smpp/operations.py
+++ b/jasmin/protocols/smpp/operations.py
@@ -6,8 +6,7 @@ from jasmin.vendor.smpp.pdu.operations import SubmitSM, DataSM
 from jasmin.protocols.smpp.configs import SMPPClientConfig
 from jasmin.vendor.smpp.pdu.pdu_types import (EsmClass, EsmClassMode, 
                                             EsmClassType, EsmClassGsmFeatures, 
-                                            MoreMessagesToSend, MessageState,
-                                            EsmClass, EsmClassMode, EsmClassType)
+                                            MoreMessagesToSend, MessageState)
 
 class UnknownMessageStatusError(Exception):
     """Raised when message_status is not recognized


### PR DESCRIPTION
Hello, Fourat!

user-id is good to see in the messages.log, so I am proposing this commit. Also replaced submit_sm_resp_bill.user.uid with the userid local variable, because I made it to be used anyway for printing in log (have rushed with the previous commit, think now's good )

Also, have discovered and removed some doubling imports in jasmin/protocols/smpp/operations.py
