### PR TITLE
Update pdu_encoding.py

### DIFF
--- a/jasmin/vendor/smpp/pdu/pdu_encoding.py
+++ b/jasmin/vendor/smpp/pdu/pdu_encoding.py
@@ -934,7 +934,7 @@ class PDUEncoder(IEncoder):
         },
         pdu_types.CommandId.deliver_sm: {
             'schedule_delivery_time': TimeEncoder(requireNull=True, decodeErrorStatus=pdu_types.CommandStatus.ESME_RINVSCHED),
-            'validity_period': TimeEncoder(requireNull=True, decodeErrorStatus=pdu_types.CommandStatus.ESME_RINVEXPIRY),
+            'validity_period': TimeEncoder(requireNull=False, decodeErrorStatus=pdu_types.CommandStatus.ESME_RINVEXPIRY),
         },
         pdu_types.CommandId.deliver_sm_resp: {
             'message_id': COctetStringEncoder(decodeNull=True, requireNull=True, decodeErrorStatus=pdu_types.CommandStatus.ESME_RINVMSGID),


### PR DESCRIPTION
This is in reference to #397

SMSC that sends us this message passes a validity_period, requiring this to be null throws a PDUParseError exception.