### PR TITLE
sm_encode changed to not to override SMSC_DEFAULT_ALPHABET to ascii

### DIFF
--- a/jasmin/vendor/smpp/pdu/sm_encoding.py
+++ b/jasmin/vendor/smpp/pdu/sm_encoding.py
@@ -19,6 +19,7 @@ from jasmin.vendor.smpp.pdu.pdu_types import *
 from jasmin.vendor.smpp.pdu.namedtuple import namedtuple
 from jasmin.vendor.smpp.pdu.gsm_types import InformationElementIdentifier
 from jasmin.vendor.smpp.pdu.gsm_encoding import UserDataHeaderEncoder
+from jasmin.vendor.messaging.sms.gsm0338 import *
 
 ShortMessageString = namedtuple('ShortMessageString', 'bytes, unicode, udh')
 
@@ -34,7 +35,7 @@ class SMStringEncoder(object):
         if data_coding.scheme == DataCodingScheme.DEFAULT:
             unicodeStr = None
             if data_coding.schemeData == DataCodingDefault.SMSC_DEFAULT_ALPHABET:
-                unicodeStr = unicode(smStrBytes, 'ascii')
+                unicodeStr = encode(unicode(smStrBytes, 'utf8'))
             elif data_coding.schemeData == DataCodingDefault.IA5_ASCII:
                 unicodeStr = unicode(smStrBytes, 'ascii')
             elif data_coding.schemeData == DataCodingDefault.UCS2:


### PR DESCRIPTION
When using Jasmin as SMPP server and  client sends data_coding as SMSC_DEFAULT_ALPHABET in sm_encoding.py, it is converted to ASCII. As there is no implicit way in SMPP 3.4 to tell server that client is using gsm0338, SMS centers are often using gsm0338 as  SMSC_DEFAULT_ALPHABET. 

I did conversion to UTF8 and then used encode() from gsm0338 to convert the message.

This might possibly broke some other functionality, but please consider merging.

