### PR TITLE
src_addr in smppccm should always be a string

### DIFF
--- a/jasmin/protocols/cli/smppccm.py
+++ b/jasmin/protocols/cli/smppccm.py
@@ -29,7 +29,7 @@ SMPPClientConfigKeyMap = {
 
 # Keys to be kept in string type, as requested in #64 and #105
 SMPPClientConfigStringKeys = [
-    'host', 'systemType', 'username', 'password', 'addressRange', 'useSSL']
+    'host', 'systemType', 'username', 'password', 'addressRange', 'useSSL', 'source_addr']
 
 # When updating a key from RequireRestartKeys, the connector need restart for update to take effect
 RequireRestartKeys = ['host', 'port', 'username', 'password', 'systemType']

--- a/misc/doc/sources/management/jcli/modules.rst
+++ b/misc/doc/sources/management/jcli/modules.rst
@@ -1190,7 +1190,7 @@ Jasmin provides many Filters offering advanced flexibilities to message routing:
      - Will match the source address of a MO message
    * - **DestinationAddrFilter**
      - All
-     - Will match the source address of a message
+     - Will match the destination address of a MT message
    * - **ShortMessageFilter**
      - All
      - Will match the content of a message


### PR DESCRIPTION
A usual MSISDN as `src_addr` (like `33612345678`) will be converted to integer, and an attempt to send an SMS-MT without specifying the source address will fail: 

Configuration:

```console
$ telnet 127.0.0.1 8990
Welcome to Jasmin 0.9.27 console
Type help or ? to list commands.

Session ref: 3
jcli : smppccm -u TEST_CON
Updating connector id [TEST_CON]: (ok: save, ko: exit)
> src_addr 33757338139
> ok
```

Test:

```sh
curl 'http://127.0.0.1:1401/send?username=user&password=password&to=33687654321&content=hello'
```

Result:

```
==> /var/log/jasmin/messages.log <==
2018-04-12 09:02:06 CRITICAL 29209 Rejecting SubmitSmPDU[xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx] through [cid:TEST_CON] for an unknown error (<type 'exceptions.AttributeError'>): 'int' object has no attribute 'encode'
```

This is now fixed in 3055de5.

Also, there is a small typo in the `DestinationAddrFilter` description, fixed as well in 12d28e9.