### PR TITLE
Multi-Part RACE Scenario Fix

### DIFF
--- a/jasmin/managers/listeners.py
+++ b/jasmin/managers/listeners.py
@@ -435,8 +435,12 @@ class SMPPClientSMListener(object):
         # @TODO: longDeliverSm part expiry must be configurable
         yield self.redisClient.expire(hashKey, 300)
 
+        increment_key = "incr" + hashKey
+        increment_value = yield self.redisClient.incr(increment_key)
+        yield self.redisClient.expire(increment_key, 300)
+
         # This is the last part
-        if segment_seqnum == total_segments:
+        if increment_value == total_segments:
             hvals = yield self.redisClient.hvals(hashKey)
             if len(hvals) != total_segments:
                 self.log.warn(


### PR DESCRIPTION
Some SMPP servers will not deliver multi-part messages in sequential order creating a RACE scenario, thus Jasmin would reject the message even though all the parts were sent. This does a counter in Redis after the message has been fully received and saved and when the count matches the total length, it sends it.

It also adds an expire to the counter same as the message so it does not sit in Redis.