### PR TITLE
Stop multi-line logging as it makes log shipping difficult

### DIFF
--- a/jasmin/interceptor/interceptor.py
+++ b/jasmin/interceptor/interceptor.py
@@ -2,6 +2,7 @@ import cPickle as pickle
 import datetime as dt
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.spread import pb
 
@@ -20,7 +21,7 @@ class InterceptorPB(pb.Avatar):
         if len(self.log.handlers) != 1:
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file, when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format, self.config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format, self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/managers/clients.py
+++ b/jasmin/managers/clients.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import time
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.internet import defer
 from twisted.spread import pb
@@ -48,7 +49,7 @@ class SMPPClientManagerPB(pb.Avatar):
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format,
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format,
                                           self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)

--- a/jasmin/managers/dlr.py
+++ b/jasmin/managers/dlr.py
@@ -1,5 +1,6 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.internet import defer
 from twisted.internet import reactor
@@ -44,7 +45,7 @@ class DLRLookup(object):
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format, self.config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format, self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/managers/listeners.py
+++ b/jasmin/managers/listeners.py
@@ -4,6 +4,7 @@ import logging
 import struct
 from datetime import datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from dateutil import parser
 from twisted.internet import defer
@@ -52,7 +53,7 @@ class SMPPClientSMListener(object):
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format, self.config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format, self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/protocols/cli/factory.py
+++ b/jasmin/protocols/cli/factory.py
@@ -1,6 +1,7 @@
 import re
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 from twisted.internet import reactor, defer
 from twisted.internet.protocol import ServerFactory
 from jasmin.protocols.cli.jcli import JCliProtocol
@@ -57,7 +58,7 @@ class JCliFactory(ServerFactory):
             self.log.setLevel(config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(config.log_format, config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(config.log_format, config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
 

--- a/jasmin/protocols/http/server.py
+++ b/jasmin/protocols/http/server.py
@@ -5,6 +5,7 @@ import re
 import binascii
 from datetime import datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.internet import reactor, defer
 from twisted.web.resource import Resource
@@ -879,7 +880,7 @@ class HTTPApi(Resource):
         if len(log.handlers) != 1:
             log.setLevel(config.log_level)
             handler = TimedRotatingFileHandler(filename=config.log_file, when=config.log_rotate)
-            formatter = logging.Formatter(config.log_format, config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(config.log_format, config.log_date_format)
             handler.setFormatter(formatter)
             log.addHandler(handler)
             log.propagate = False

--- a/jasmin/protocols/rest/__init__.py
+++ b/jasmin/protocols/rest/__init__.py
@@ -7,6 +7,8 @@ import sys
 from .api import PingResource, BalanceResource, RateResource, SendResource, SendBatchResource
 from .config import *
 
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
+
 sys.path.append("%s/vendor" % os.path.dirname(os.path.abspath(jasmin.__file__)))
 import falcon
 
@@ -15,7 +17,7 @@ logger = logging.getLogger('jasmin-restapi')
 if len(logger.handlers) == 0:
     logger.setLevel(log_level)
     handler = logging.handlers.TimedRotatingFileHandler(filename=log_file, when=log_rotate)
-    handler.setFormatter(logging.Formatter(log_format, log_date_format))
+    handler.setFormatter(WhiteSpaceStrippingFormatter(log_format, log_date_format))
     logger.addHandler(handler)
 
 

--- a/jasmin/protocols/rest/tasks.py
+++ b/jasmin/protocols/rest/tasks.py
@@ -5,6 +5,8 @@ from celery import Celery, Task
 from celery.task import task
 from datetime import datetime, timedelta
 
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
+
 from .config import *
 
 # @TODO: make configuration loadable from /etc/jasmin/restapi.conf
@@ -12,7 +14,7 @@ logger = logging.getLogger('jasmin-restapi')
 if len(logger.handlers) == 0:
     logger.setLevel(log_level)
     handler = logging.handlers.TimedRotatingFileHandler(filename=log_file, when=log_rotate)
-    handler.setFormatter(logging.Formatter(log_format, log_date_format))
+    handler.setFormatter(WhiteSpaceStrippingFormatter(log_format, log_date_format))
     logger.addHandler(handler)
 
 app = Celery(__name__)

--- a/jasmin/protocols/smpp/factory.py
+++ b/jasmin/protocols/smpp/factory.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from OpenSSL import SSL
 from twisted.internet import defer, reactor, ssl
@@ -48,7 +49,7 @@ class SMPPClientFactory(ClientFactory):
             self.log.setLevel(config.log_level)
             _when = self.config.log_rotate if hasattr(self.config, 'log_rotate') else 'midnight'
             handler = TimedRotatingFileHandler(filename=self.config.log_file, when=_when)
-            formatter = logging.Formatter(config.log_format, config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(config.log_format, config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False
@@ -224,7 +225,7 @@ class SMPPServerFactory(_SMPPServerFactory):
         if len(self.log.handlers) != 1:
             self.log.setLevel(config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file, when=self.config.log_rotate)
-            formatter = logging.Formatter(config.log_format, config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(config.log_format, config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/protocols/smpp/pb.py
+++ b/jasmin/protocols/smpp/pb.py
@@ -1,6 +1,7 @@
 import cPickle as pickle
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.internet import defer
 from twisted.spread import pb
@@ -21,7 +22,7 @@ class SMPPServerPB(pb.Avatar):
         if len(self.log.handlers) != 1:
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file, when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format, self.config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format, self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/protocols/smpp/services.py
+++ b/jasmin/protocols/smpp/services.py
@@ -1,5 +1,6 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 from jasmin.protocols.smpp.factory import SMPPClientFactory
 from twisted.application import service
 from .configs import SMPPClientServiceConfig
@@ -23,7 +24,7 @@ class SMPPClientService(service.Service):
             handler = TimedRotatingFileHandler(
                 filename=self.SMPPClientServiceConfig.log_file,
                 when=self.SMPPClientServiceConfig.log_rotate)
-            formatter = logging.Formatter(self.SMPPClientServiceConfig.log_format,
+            formatter = WhiteSpaceStrippingFormatter(self.SMPPClientServiceConfig.log_format,
                                           self.SMPPClientServiceConfig.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)

--- a/jasmin/queues/factory.py
+++ b/jasmin/queues/factory.py
@@ -1,6 +1,7 @@
 # pylint: disable=E0203
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 from twisted.internet.protocol import ClientFactory
 from twisted.internet import defer, reactor
 from txamqp.client import TwistedDelegate
@@ -32,7 +33,7 @@ class AmqpFactory(ClientFactory):
             self.log.setLevel(config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(config.log_format, config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(config.log_format, config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/redis/client.py
+++ b/jasmin/redis/client.py
@@ -1,5 +1,6 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 import jasmin.vendor.txredisapi as redis
 from twisted.internet import reactor
 from twisted.internet import defer
@@ -46,7 +47,7 @@ class RedisForJasminFactory(redis.RedisFactory):
             self.log.setLevel(config.log_level)
             handler = TimedRotatingFileHandler(filename=config.log_file,
                                                when=config.log_rotate)
-            formatter = logging.Formatter(config.log_format, config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(config.log_format, config.log_date_format)
             handler.setFormatter(formatter)
         else:
             handler = logging.NullHandler()

--- a/jasmin/routing/router.py
+++ b/jasmin/routing/router.py
@@ -4,6 +4,7 @@ import time
 from copy import copy
 from hashlib import md5
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.internet import defer, reactor
 from twisted.spread import pb
@@ -32,7 +33,7 @@ class RouterPB(pb.Avatar):
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format, self.config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format, self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/routing/throwers.py
+++ b/jasmin/routing/throwers.py
@@ -3,6 +3,7 @@ import cPickle as pickle
 import logging
 import urllib
 from logging.handlers import TimedRotatingFileHandler
+from jasmin.tools.formatters import WhiteSpaceStrippingFormatter
 
 from twisted.application.service import Service
 from twisted.internet import defer
@@ -73,7 +74,7 @@ class Thrower(Service):
             self.log.setLevel(self.config.log_level)
             handler = TimedRotatingFileHandler(filename=self.config.log_file,
                                                when=self.config.log_rotate)
-            formatter = logging.Formatter(self.config.log_format, self.config.log_date_format)
+            formatter = WhiteSpaceStrippingFormatter(self.config.log_format, self.config.log_date_format)
             handler.setFormatter(formatter)
             self.log.addHandler(handler)
             self.log.propagate = False

--- a/jasmin/tools/formatters.py
+++ b/jasmin/tools/formatters.py
@@ -1,0 +1,5 @@
+import logging
+
+class WhiteSpaceStrippingFormatter(logging.Formatter):
+    def format(self, record):
+        return super(WhiteSpaceStrippingFormatter, self).format(record).replace('\n', '').replace('\r', '')

--- a/jasmin/vendor/smpp/pdu/pdu_types.py
+++ b/jasmin/vendor/smpp/pdu/pdu_types.py
@@ -154,11 +154,11 @@ class PDU(object):
         r = "PDU [command: %s, sequence_number: %s, command_status: %s" % (self.id, self.seqNum, self.status)
         for mParam in self.mandatoryParams:
             if mParam in self.params:
-                r += "\n%s: %r" % (mParam, self.params[mParam])
+                r += " %s: %r" % (mParam, self.params[mParam])
         for oParam in self.params.keys():
             if oParam not in self.mandatoryParams:
-                r += "\n%s: %r" % (oParam, self.params[oParam])                
-        r += '\n]'
+                r += " %s: %r" % (oParam, self.params[oParam])                
+        r += ']'
         return r
         
     def __eq__(self, pdu):


### PR DESCRIPTION
Use spaces rather than line breaks in logs to preserve single line logging