### PR TITLE
SMPP PDU: Add support for additional_status_info_text in Deliver_sm PDUs

### DIFF
--- a/jasmin/vendor/smpp/pdu/operations.py
+++ b/jasmin/vendor/smpp/pdu/operations.py
@@ -264,6 +264,7 @@ class DeliverSM(PDUDataRequest):
         'network_error_code',
         'message_state',
         'receipted_message_id',
+        'additional_status_info_text'
     ]
 
 class DataSMResp(PDUResponse):


### PR DESCRIPTION
Seems a pretty common header, as per some other issues raised on this repo