### PR TITLE
AMQP Factory: Exit on connection failure/loss

### DIFF
--- a/jasmin/queues/factory.py
+++ b/jasmin/queues/factory.py
@@ -1,5 +1,6 @@
 # pylint: disable=E0203
 import logging
+import os,signal
 from logging.handlers import TimedRotatingFileHandler
 from twisted.internet.protocol import ClientFactory
 from twisted.internet import defer, reactor
@@ -91,6 +92,7 @@ class AmqpFactory(ClientFactory):
             self.connectDeferred.errback(reason)
             self.exitDeferred.callback(self)
             self.log.info("Exiting.")
+            os.kill(os.getpid(), signal.SIGINT)
 
     def clientConnectionLost(self, connector, reason):
         """Connection lost
@@ -107,6 +109,7 @@ class AmqpFactory(ClientFactory):
         else:
             self.exitDeferred.callback(self)
             self.log.info("Exiting.")
+            os.kill(os.getpid(), signal.SIGINT)
 
     def reConnect(self, connector=None):
         if connector is None:


### PR DESCRIPTION
Not my finest pull request but desperation prevailed and comments are welcome.

AMQP reconnect logic in Jasmin is pretty much useless as AMQP basic_consume is not done upon reconnection so no messages are ever consumed. Fixing this is impossibly hard as it's all done in Defers.

The best way to ensure resiliency in the event of RabbitMQ failure is to cause Jasmin to exit by setting **connection_loss_retry** to **False** in the Jasmin configuration. However, as it stands, this just causes Jasmin to log "Exiting." rather than actually exit. This PR fixes that.

Exiting cleanly is also a bit of a challenge as you don't have access to the JasminDaemon object at the point you need to exit. Jasmin defines SIGINT as an exit code and it cleans up lock files etc. when received so sending this signal seems to be the easiest way to get it to exit cleanly.