### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# install the compatible PIP version
+RUN pip install pip==20.3.3
+
 # Install Jasmin SMS gateway
 RUN mkdir -p /etc/jasmin/resource \
     /etc/jasmin/store \


### PR DESCRIPTION
PIP version is needed to be compatible with 2.7 to avoid compatibility issues with latest pip versions