### PR TITLE
Fix packaging

### DIFF
--- a/jasmin/protocols/rest/tasks.py
+++ b/jasmin/protocols/rest/tasks.py
@@ -95,19 +95,15 @@ def httpapi_send(self, batch_id, batch_config, message_params, config):
 
         # Return status back
         if r.status_code != 200:
-            logger.error('[%s] %s' % (batch_id, r.content.strip('"')))
+            logger.error('[%s] %s' % (batch_id, r.text.strip('"')))
             if batch_config.get('errback_url', None):
                 batch_callback.delay(
                     batch_config.get('errback_url'), batch_id, message_params['to'], 0,
-                    'HTTPAPI error: %s' % r.content.strip('"'))
+                    'HTTPAPI error: %s' % r.text.strip('"'))
         else:
             if batch_config.get('callback_url', None):
-                if isinstance(r.content, bytes) and r.text:
-                    resp_content = r.text
-                else:
-                    resp_content = r.content
                 batch_callback.delay(
-                    batch_config.get('callback_url'), batch_id, message_params['to'], 1, resp_content)
+                    batch_config.get('callback_url'), batch_id, message_params['to'], 1, r.text)
 
 
 @task(bind=True, base=JasminTask)

--- a/jasmin/protocols/rest/tasks.py
+++ b/jasmin/protocols/rest/tasks.py
@@ -102,9 +102,10 @@ def httpapi_send(self, batch_id, batch_config, message_params, config):
                     'HTTPAPI error: %s' % r.content.strip('"'))
         else:
             if batch_config.get('callback_url', None):
-                resp_content = r.content
-                if isinstance(resp_content, bytes):
-                    resp_content = str(r.content)
+                if isinstance(r.content, bytes) and r.text:
+                    resp_content = r.text
+                else:
+                    resp_content = r.content
                 batch_callback.delay(
                     batch_config.get('callback_url'), batch_id, message_params['to'], 1, resp_content)
 

--- a/jasmin/protocols/rest/tasks.py
+++ b/jasmin/protocols/rest/tasks.py
@@ -102,8 +102,11 @@ def httpapi_send(self, batch_id, batch_config, message_params, config):
                     'HTTPAPI error: %s' % r.content.strip('"'))
         else:
             if batch_config.get('callback_url', None):
+                resp_content = r.content
+                if isinstance(resp_content, bytes):
+                    resp_content = str(r.content)
                 batch_callback.delay(
-                    batch_config.get('callback_url'), batch_id, message_params['to'], 1, r.content)
+                    batch_config.get('callback_url'), batch_id, message_params['to'], 1, resp_content)
 
 
 @task(bind=True, base=JasminTask)

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -32,10 +32,15 @@ replaces:
   - jasmin-sms-gateway
 provides:
   - jasmin-sms-gateway
-empty_folders:
-  - /var/log/jasmin
-  - /etc/jasmin/store
 contents:
+  - dst: /var/log/jasmin
+    type: dir
+    file_info:
+      mode: 0700
+  - dst: /etc/jasmin/store
+    type: dir
+    file_info:
+      mode: 0700
   - src: ./misc/config/jasmin.cfg
     dst: "/etc/jasmin/jasmin.cfg"
     type: config


### PR DESCRIPTION
empty_folders setting was removed since nfpm 2.17. Trying to build
jasmin package with decent nfpm triggers the error:

```
$ nfpm pkg --packager deb --target /tmp/
yaml: unmarshal errors:
  line 35: field empty_folders not found in type nfpm.Config
```
Update nfpm.yaml to fix packaging

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
