### PR TITLE
cast logprivacy to boolean

### DIFF
--- a/jasmin/protocols/cli/smppccm.py
+++ b/jasmin/protocols/cli/smppccm.py
@@ -67,7 +67,7 @@ def castInputToBuiltInType(key, value):
             return replace_if_present_flap_value_map[value]
         elif key == 'priority':
             return priority_flag_value_map[value]
-        elif key in ['con_fail_retry', 'con_loss_retry', 'ssl']:
+        elif key in ['con_fail_retry', 'con_loss_retry', 'ssl', 'logprivacy']:
             if value == 'yes':
                 return True
             elif value == 'no':


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Fix  `Error: log_privacy must be a boolean` when trying to change logprivacy for smppccm in cli.
