### PR TITLE
Cli interceptors accepts url

### DIFF
--- a/jasmin/protocols/cli/mointerceptorm.py
+++ b/jasmin/protocols/cli/mointerceptorm.py
@@ -22,7 +22,7 @@ def validate_typed_script(script):
 
     m = re.match(r'(python3)\((.*)\)', script, re.I)
     if not m:
-        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script) or python3(https://domain.com/path/to/script).')
+        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script).')
     else:
         language = m.group(1).lower()
         script_path = m.group(2)

--- a/jasmin/protocols/cli/mointerceptorm.py
+++ b/jasmin/protocols/cli/mointerceptorm.py
@@ -22,7 +22,7 @@ def validate_typed_script(script):
 
     m = re.match(r'(python3)\((.*)\)', script, re.I)
     if not m:
-        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script).')
+        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script) or python3(https://domain.com/path/to/script).')
     else:
         language = m.group(1).lower()
         script_path = m.group(2)

--- a/jasmin/protocols/cli/mointerceptorm.py
+++ b/jasmin/protocols/cli/mointerceptorm.py
@@ -133,9 +133,20 @@ def MOInterceptorBuild(fCallback):
                         stype, script_path = validate_typed_script(arg)
 
                         if stype == 'python3':
-                            # Open file and get its content
-                            with open(script_path, 'r') as content_file:
-                                pyCode = content_file.read()
+                            import os
+                            if os.path.isfile(script_path):
+                                # Open file and get its content
+                                with open(script_path, 'r') as content_file:
+                                    pyCode = content_file.read()
+                            else:
+                                # Assume it's a URL
+                                import urllib.request
+                                try:
+                                    with urllib.request.urlopen(script_path) as content_file:
+                                        pyCode = content_file.read().decode('utf-8')
+                                except urllib.error.URLError as e:
+                                    # Handle errors that may occur while reading the file from a URL
+                                    return self.protocol.sendData('[URL]: %s' % str(e))
 
                             # Test compilation of the script
                             compile(pyCode, '', 'exec')

--- a/jasmin/protocols/cli/mointerceptorm.py
+++ b/jasmin/protocols/cli/mointerceptorm.py
@@ -133,13 +133,13 @@ def MOInterceptorBuild(fCallback):
                         stype, script_path = validate_typed_script(arg)
 
                         if stype == 'python3':
-                            import os
-                            import urllib
-                            if os.path.isfile(script_path):
+                            import urllib.parse, urllib.request, urllib.error
+                            pathscheme = urllib.parse.urlparse(script_path).scheme
+                            if pathscheme == '':
                                 # Open file and get its content
                                 with open(script_path, 'r') as content_file:
                                     pyCode = content_file.read()
-                            elif urllib.parse.urlparse(script_path).scheme in ['https', 'http', 'ftp', 'file']:
+                            elif pathscheme in ['https', 'http', 'ftp', 'file']:
                                 try:
                                     with urllib.request.urlopen(script_path) as content_file:
                                         pyCode = content_file.read().decode('utf-8')

--- a/jasmin/protocols/cli/mointerceptorm.py
+++ b/jasmin/protocols/cli/mointerceptorm.py
@@ -134,19 +134,20 @@ def MOInterceptorBuild(fCallback):
 
                         if stype == 'python3':
                             import os
+                            import urllib
                             if os.path.isfile(script_path):
                                 # Open file and get its content
                                 with open(script_path, 'r') as content_file:
                                     pyCode = content_file.read()
-                            else:
-                                # Assume it's a URL
-                                import urllib.request
+                            elif urllib.parse.urlparse(script_path).scheme in ['https', 'http', 'ftp', 'file']:
                                 try:
                                     with urllib.request.urlopen(script_path) as content_file:
                                         pyCode = content_file.read().decode('utf-8')
                                 except urllib.error.URLError as e:
                                     # Handle errors that may occur while reading the file from a URL
                                     return self.protocol.sendData('[URL]: %s' % str(e))
+                            else:
+                                raise NotImplementedError("Not implemented yet !")
 
                             # Test compilation of the script
                             compile(pyCode, '', 'exec')

--- a/jasmin/protocols/cli/mointerceptorm.py
+++ b/jasmin/protocols/cli/mointerceptorm.py
@@ -2,6 +2,7 @@
 import re
 import inspect
 import pickle
+import urllib.parse, urllib.request, urllib.error
 from jasmin.protocols.cli.managers import PersistableManager, Session
 from jasmin.protocols.cli.filtersm import MOFILTERS
 from jasmin.routing.jasminApi import MOInterceptorScript
@@ -133,7 +134,6 @@ def MOInterceptorBuild(fCallback):
                         stype, script_path = validate_typed_script(arg)
 
                         if stype == 'python3':
-                            import urllib.parse, urllib.request, urllib.error
                             pathscheme = urllib.parse.urlparse(script_path).scheme
                             if pathscheme == '':
                                 # Open file and get its content

--- a/jasmin/protocols/cli/mtinterceptorm.py
+++ b/jasmin/protocols/cli/mtinterceptorm.py
@@ -22,7 +22,7 @@ def validate_typed_script(script):
 
     m = re.match(r'(python3)\((.*)\)', script, re.I)
     if not m:
-        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script) or python3(https://domain.com/path/to/script).')
+        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script).')
     else:
         language = m.group(1).lower()
         script_path = m.group(2)

--- a/jasmin/protocols/cli/mtinterceptorm.py
+++ b/jasmin/protocols/cli/mtinterceptorm.py
@@ -22,7 +22,7 @@ def validate_typed_script(script):
 
     m = re.match(r'(python3)\((.*)\)', script, re.I)
     if not m:
-        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script).')
+        raise InvalidScriptSyntax('Invalid syntax for script, must be python3(/path/to/script) or python3(https://domain.com/path/to/script).')
     else:
         language = m.group(1).lower()
         script_path = m.group(2)

--- a/jasmin/protocols/cli/mtinterceptorm.py
+++ b/jasmin/protocols/cli/mtinterceptorm.py
@@ -2,6 +2,7 @@
 import re
 import inspect
 import pickle
+import urllib.parse, urllib.request, urllib.error
 from jasmin.protocols.cli.managers import PersistableManager, Session
 from jasmin.protocols.cli.filtersm import MTFILTERS
 from jasmin.routing.jasminApi import MTInterceptorScript
@@ -133,7 +134,6 @@ def MTInterceptorBuild(fCallback):
                         stype, script_path = validate_typed_script(arg)
 
                         if stype == 'python3':
-                            import urllib.parse, urllib.request, urllib.error
                             pathscheme = urllib.parse.urlparse(script_path).scheme
                             if pathscheme == '':
                                 # Open file and get its content

--- a/jasmin/protocols/cli/mtinterceptorm.py
+++ b/jasmin/protocols/cli/mtinterceptorm.py
@@ -133,13 +133,13 @@ def MTInterceptorBuild(fCallback):
                         stype, script_path = validate_typed_script(arg)
 
                         if stype == 'python3':
-                            import os
-                            import urllib
-                            if os.path.isfile(script_path):
+                            import urllib.parse, urllib.request, urllib.error
+                            pathscheme = urllib.parse.urlparse(script_path).scheme
+                            if pathscheme == '':
                                 # Open file and get its content
                                 with open(script_path, 'r') as content_file:
                                     pyCode = content_file.read()
-                            elif urllib.parse.urlparse(script_path).scheme in ['https', 'http', 'ftp', 'file']:
+                            elif pathscheme in ['https', 'http', 'ftp', 'file']:
                                 try:
                                     with urllib.request.urlopen(script_path) as content_file:
                                         pyCode = content_file.read().decode('utf-8')

--- a/jasmin/protocols/cli/mtinterceptorm.py
+++ b/jasmin/protocols/cli/mtinterceptorm.py
@@ -134,19 +134,20 @@ def MTInterceptorBuild(fCallback):
 
                         if stype == 'python3':
                             import os
+                            import urllib
                             if os.path.isfile(script_path):
                                 # Open file and get its content
                                 with open(script_path, 'r') as content_file:
                                     pyCode = content_file.read()
-                            else:
-                                # Assume it's a URL
-                                import urllib.request
+                            elif urllib.parse.urlparse(script_path).scheme in ['https', 'http', 'ftp', 'file']:
                                 try:
                                     with urllib.request.urlopen(script_path) as content_file:
                                         pyCode = content_file.read().decode('utf-8')
                                 except urllib.error.URLError as e:
                                     # Handle errors that may occur while reading the file from a URL
                                     return self.protocol.sendData('[URL]: %s' % str(e))
+                            else:
+                                raise NotImplementedError("Not implemented yet !")
 
                             # Test compilation of the script
                             compile(pyCode, '', 'exec')

--- a/jasmin/protocols/cli/mtinterceptorm.py
+++ b/jasmin/protocols/cli/mtinterceptorm.py
@@ -133,9 +133,20 @@ def MTInterceptorBuild(fCallback):
                         stype, script_path = validate_typed_script(arg)
 
                         if stype == 'python3':
-                            # Open file and get its content
-                            with open(script_path, 'r') as content_file:
-                                pyCode = content_file.read()
+                            import os
+                            if os.path.isfile(script_path):
+                                # Open file and get its content
+                                with open(script_path, 'r') as content_file:
+                                    pyCode = content_file.read()
+                            else:
+                                # Assume it's a URL
+                                import urllib.request
+                                try:
+                                    with urllib.request.urlopen(script_path) as content_file:
+                                        pyCode = content_file.read().decode('utf-8')
+                                except urllib.error.URLError as e:
+                                    # Handle errors that may occur while reading the file from a URL
+                                    return self.protocol.sendData('[URL]: %s' % str(e))
 
                             # Test compilation of the script
                             compile(pyCode, '', 'exec')

--- a/misc/doc/sources/management/jcli/modules.rst
+++ b/misc/doc/sources/management/jcli/modules.rst
@@ -736,6 +736,12 @@ Here's an example of adding a **DefaultInterceptor** to a python script::
 
 .. note:: As of now, only **python3** script is permitted.
 
+.. note:: The path to the script can be any of the fallowing:
+  
+    * **python3(/path/to/script.py)** or **python3(file://path/to/script.py)**: The path must be absolute, relative path is not supported
+    * **python3(https://example.com/path/to/script.py)**: The script is a remote python3 script. The script will be
+      downloaded and copied to Jasmin core. Accepts http, https, and ftp protocols.
+
 .. note:: Pay attention that the given script is copied to Jasmin core, do not expect Jasmin to refresh the script
   code when you update it, you'll need to redefine the *mointerceptor* rule again so Jasmin will refresh the script.
 


### PR DESCRIPTION
CLI protocol for interceptors, You can pass a url for script same as file path. using same syntax python3(https://domain.com/path/to/script). The path can be http://, https://, ftp://, or file://


### Checks
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
