### PR TITLE
Adjust logging according to last part of the message

### DIFF
--- a/jasmin/managers/listeners.py
+++ b/jasmin/managers/listeners.py
@@ -291,10 +291,12 @@ class SMPPClientSMListener:
                     splitMethod = 'sar'
                 elif UDHI_INDICATOR_SET and r.request.params['short_message'][:3] == b'\x05\x00\x03':
                     splitMethod = 'udh'
+                    
+                # create _pdu before splitting, so we can use it in both branches (logging the message according the last part of message)
+                _pdu = r.request
 
                 # Concatenate short_message
                 if splitMethod is not None:
-                    _pdu = r.request
                     if splitMethod == 'sar':
                         short_message = _pdu.params['short_message']
                     else:
@@ -328,12 +330,12 @@ class SMPPClientSMListener:
                     r.response.params['message_id'],
                     r.response.status,
                     amqpMessage.content.properties['priority'],
-                    r.request.params['registered_delivery'].receipt,
+                    _pdu.params['registered_delivery'].receipt,
                     'none' if ('headers' not in amqpMessage.content.properties or
                                'expiration' not in amqpMessage.content.properties['headers'])
                     else amqpMessage.content.properties['headers']['expiration'],
-                    r.request.params['source_addr'],
-                    r.request.params['destination_addr'],
+                    _pdu.params['source_addr'],
+                    _pdu.params['destination_addr'],
                     logged_content)
             else:
                 # Message must be retried ?


### PR DESCRIPTION
### Description
Adjust logging to log sent message according to last PDU parameters.

I found this was logged bad when investigating https://github.com/jookies/jasmin/issues/1136.
Jasmin works OK, but logs something different than it actually does. This can mislead the user.