### PR TITLE
memory leak in router/thrower lead to RabbitMQ unacked timeout

### DIFF
--- a/jasmin/routing/throwers.py
+++ b/jasmin/routing/throwers.py
@@ -98,20 +98,20 @@ class Thrower(Service):
         self.log.info('Added a %s access to SMPPServerFactory', self.smpps_access)
 
     def getThrowingRetrials(self, message):
-        return self.throwing_retrials.get(message.content.properties['message-id'], 0)
+        return self.throwing_retrials.get(self.getMessageUniqueId(message=message), 0)
 
     def delThrowingRetrials(self, message):
-        if message.content.properties['message-id'] in self.throwing_retrials:
-            del self.throwing_retrials[message.content.properties['message-id']]
+        if self.getMessageUniqueId(message=message) in self.throwing_retrials:
+            del self.throwing_retrials[self.getMessageUniqueId(message=message)]
             return True
         else:
             return False
 
     def incThrowingRetrials(self, message):
-        if message.content.properties['message-id'] in self.throwing_retrials:
-            self.throwing_retrials[message.content.properties['message-id']] += 1
+        if self.getMessageUniqueId(message=message) in self.throwing_retrials:
+            self.throwing_retrials[self.getMessageUniqueId(message=message)] += 1
         else:
-            self.throwing_retrials[message.content.properties['message-id']] = 1
+            self.throwing_retrials[self.getMessageUniqueId(message=message)] = 1
 
     def throwing_callback(self, message):
         # Init retrial mechanism
@@ -194,9 +194,9 @@ class Thrower(Service):
                                       requeue=1)
 
             # If any, clear timer before setting a new one
-            self.clearRequeueTimer(msgid)
+            self.clearRequeueTimer(self.getMessageUniqueId(message=message))
 
-            self.requeueTimers[msgid] = timer
+            self.requeueTimers[self.getMessageUniqueId(message=message)] = timer
             defer.returnValue(timer)
         else:
             self.log.debug("Requeuing Content[%s] without delay", msgid)
@@ -216,6 +216,12 @@ class Thrower(Service):
         self.delThrowingRetrials(message)
 
         yield self.amqpBroker.chan.basic_ack(message.delivery_tag)
+    
+    def getMessageUniqueId(self, message):
+        uniqueId = message.content.properties['message-id']
+        if 'headers' in message.content.properties and 'level' in message.content.properties['headers']:
+            uniqueId += '-%s' % message.content.properties['headers']['level']
+        return uniqueId
 
 
 class deliverSmThrower(Thrower):
@@ -240,7 +246,7 @@ class deliverSmThrower(Thrower):
         self.log.debug('Got one message (msgid:%s) to throw: %s', msgid, RoutedDeliverSmContent)
 
         # If any, clear requeuing timer
-        self.clearRequeueTimer(msgid)
+        self.clearRequeueTimer(self.getMessageUniqueId(message=message))
 
         if dcs[0]._type != 'http':
             self.log.error(
@@ -392,7 +398,7 @@ class deliverSmThrower(Thrower):
         self.log.debug('Got one message (msgid:%s) to throw: %s', msgid, RoutedDeliverSmContent)
 
         # If any, clear requeuing timer
-        self.clearRequeueTimer(msgid)
+        self.clearRequeueTimer(self.getMessageUniqueId(message=message))
 
         if dcs[0]._type != 'smpps':
             self.log.error(
@@ -524,7 +530,7 @@ class DLRThrower(Thrower):
         self.log.debug('Got one message (msgid:%s) to throw', msgid)
 
         # If any, clear requeuing timer
-        self.clearRequeueTimer(msgid)
+        self.clearRequeueTimer(self.getMessageUniqueId(message=message))
 
         # Build mandatory arguments
         args = {
@@ -621,7 +627,7 @@ class DLRThrower(Thrower):
             err = err.encode('ascii')
 
         # If any, clear requeuing timer
-        self.clearRequeueTimer(msgid)
+        self.clearRequeueTimer(self.getMessageUniqueId(message=message))
 
         try:
             if self.smpps is None or self.smpps_access is None:

--- a/jasmin/routing/throwers.py
+++ b/jasmin/routing/throwers.py
@@ -218,8 +218,10 @@ class Thrower(Service):
         yield self.amqpBroker.chan.basic_ack(message.delivery_tag)
     
     def getMessageUniqueId(self, message):
-        # get a unique id for this message. dlr level 1 and 2 are different payloads but share the same id
-        return '%s-%s' % (message.content.properties['message-id'], message.delivery_tag)
+        uniqueId = message.content.properties['message-id']
+        if 'headers' in message.content.properties and 'level' in message.content.properties['headers']:
+            uniqueId += '-%s' % message.content.properties['headers']['level']
+        return uniqueId
 
 
 class deliverSmThrower(Thrower):

--- a/jasmin/routing/throwers.py
+++ b/jasmin/routing/throwers.py
@@ -218,10 +218,8 @@ class Thrower(Service):
         yield self.amqpBroker.chan.basic_ack(message.delivery_tag)
     
     def getMessageUniqueId(self, message):
-        uniqueId = message.content.properties['message-id']
-        if 'headers' in message.content.properties and 'level' in message.content.properties['headers']:
-            uniqueId += '-%s' % message.content.properties['headers']['level']
-        return uniqueId
+        # get a unique id for this message. dlr level 1 and 2 are different payloads but share the same id
+        return '%s-%s' % (message.content.properties['message-id'], message.delivery_tag)
 
 
 class deliverSmThrower(Thrower):


### PR DESCRIPTION
### Description
The memory leak is in the thrower router. when dlr level 3 is requested: if level 1 and level 2 are both in the queue, then both have the same message-id. added a function to create a unique id [message-id-level]. when it is not a dlr it will be [message-id-]. Possible same problem in Issue #1142 
i don't know enough about managers and no testing setup for it to tinker with manager/dlr. but i suspect the same problem there. @farirat, please check there. 😊👍


### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed
