### PR TITLE
udh segment_seqnum from the current part not always read it from first part

### DIFF
--- a/jasmin/protocols/smpp/protocol.py
+++ b/jasmin/protocols/smpp/protocol.py
@@ -310,9 +310,9 @@ class SMPPClientProtocol(twistedSMPPClientProtocol):
                         partedSmPdu.LongSubmitSm['segment_seqnum'] = partedSmPdu.params['sar_segment_seqnum']
                     elif splitMethod == 'udh':
                         # Using UDH options:
-                        partedSmPdu.LongSubmitSm['msg_ref_num'] = pdu.params['short_message'][3]
-                        partedSmPdu.LongSubmitSm['total_segments'] = pdu.params['short_message'][4]
-                        partedSmPdu.LongSubmitSm['segment_seqnum'] = pdu.params['short_message'][5]
+                        partedSmPdu.LongSubmitSm['msg_ref_num'] = partedSmPdu.params['short_message'][3]
+                        partedSmPdu.LongSubmitSm['total_segments'] = partedSmPdu.params['short_message'][4]
+                        partedSmPdu.LongSubmitSm['segment_seqnum'] = partedSmPdu.params['short_message'][5]
 
                     self.preSubmitSm(partedSmPdu)
                     self.sendPDU(partedSmPdu)


### PR DESCRIPTION
No Fix. but udh is broken. Still tracking

### Description
Read the segment_seqnum from the current pdu instead of reading it from the original pdu. It was always passed on as 1


### Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed
