### PR TITLE
Update Dockerfile.restapi

### DIFF
--- a/docker/Dockerfile.restapi
+++ b/docker/Dockerfile.restapi
@@ -5,6 +5,10 @@ MAINTAINER Jookies LTD <jasmin@jookies.net>
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r jasmin && useradd -r -g jasmin jasmin
 
+
+# Install git To avoid issues (No such file or directory: 'git' while executing command git version) with git when cloning this repository and building docker compose from the clone
+RUN apt-get update && apt-get install -y git
+
 # Install requirements
 RUN apt-get update && apt-get install -y \
     libffi-dev \


### PR DESCRIPTION
Install git To avoid issues (No such file or directory: 'git' while executing command git version) with git when cloning this repository and building docker compose from the clone
