### PR TITLE
Align Service Hostnames with Dockerfile Defaults for Redis and RabbitMQ

### DIFF
--- a/kubernetes/simple-pods/jasmin.yml
+++ b/kubernetes/simple-pods/jasmin.yml
@@ -225,10 +225,10 @@ data:
       max_retries = 2
       
       [amqp-broker]
-      host = rabbitmq-broker
+      host = rabbitmq
       
       [redis-client]
-      host = redis-server
+      host = redis
       poolsize = 30
     
       [jcli]
@@ -256,10 +256,10 @@ data:
       dlr_lookup_max_retries = 1
 
       [amqp-broker]
-      host = rabbitmq-broker
+      host = rabbitmq
       
       [redis-client]
-      host = redis-server
+      host = redis
       poolsize = 30
 ---
 apiVersion: v1
@@ -277,8 +277,8 @@ data:
       max_retries = 1
       
       [amqp-broker]
-      host = rabbitmq-broker
+      host = rabbitmq
       
       [redis-client]
-      host = redis-server
+      host = redis
       poolsize = 30

--- a/kubernetes/simple-pods/rabbitmq.yml
+++ b/kubernetes/simple-pods/rabbitmq.yml
@@ -30,7 +30,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: rabbitmq-broker
+  name: rabbitmq
 spec:
   selector:
     name: rabbit

--- a/kubernetes/simple-pods/redis.yml
+++ b/kubernetes/simple-pods/redis.yml
@@ -26,7 +26,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis-server
+  name: redis
 spec:
   selector:
     name: redis


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Fix #1212

### Description
The Redis and RabbitMQ services are configured via a Dockerfile, which is hard-coded to use the following environment variables. Therefore, for the default installation, jasmin.yml, redisy.yml and rabbitmq.yml files should point to 'rabbitmq' instead of 'rabbitmq-broker' and 'redis' instead of 'redis-server'.

```dockerfile
# Default Redis and RabbitMQ connections
ENV AMQP_BROKER_HOST 'rabbitmq'
ENV AMQP_BROKER_PORT 5672
ENV REDIS_CLIENT_HOST 'redis'
ENV REDIS_CLIENT_PORT 6379
```

Issue References:
https://groups.google.com/g/jasmin-sms-gateway/c/k3CFXWGFW-w
https://github.com/jookies/jasmin/issues/1212
https://github.com/jookies/jasmin/issues/944

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
