### PR TITLE
Durable Queues

### DIFF
--- a/jasmin/managers/clients.py
+++ b/jasmin/managers/clients.py
@@ -241,20 +241,25 @@ class SMPPClientManagerPB(pb.Avatar):
             self.log.error('AMQP Broker channel is not yet ready')
             defer.returnValue(False)
 
-        # Fix prefetch limit per consumer to 1 to get correct throttling
-        yield self.amqpBroker.chan.basic_qos(prefetch_count=1)
+        @defer.inlineCallbacks
+        def setupQueue():
+            # Fix prefetch limit per consumer to 1 to get correct throttling
+            yield self.amqpBroker.chan.basic_qos(prefetch_count=1)
 
-        # Declare queues
-        # First declare the messaging exchange (has no effect if its already declared)
-        yield self.amqpBroker.chan.exchange_declare(exchange='messaging', type='topic')
-        # submit.sm queue declaration and binding
-        submit_sm_queue = 'submit.sm.%s' % c.id
-        routing_key = 'submit.sm.%s' % c.id
-        self.log.info('Binding %s queue to %s route_key', submit_sm_queue, routing_key)
-        yield self.amqpBroker.named_queue_declare(queue=submit_sm_queue)
-        yield self.amqpBroker.chan.queue_bind(queue=submit_sm_queue,
-                                              exchange="messaging",
-                                              routing_key=routing_key)
+            # Declare queues
+            # First declare the messaging exchange (has no effect if its already declared)
+            yield self.amqpBroker.chan.exchange_declare(exchange='messaging', type='topic')
+            # submit.sm queue declaration and binding
+            submit_sm_queue = 'submit.sm.%s' % c.id
+            routing_key = 'submit.sm.%s' % c.id
+            self.log.info('Binding %s queue to %s route_key', submit_sm_queue, routing_key)
+            yield self.amqpBroker.named_queue_declare(queue=submit_sm_queue, durable=True)
+            yield self.amqpBroker.chan.queue_bind(queue=submit_sm_queue,
+                                                exchange="messaging",
+                                                routing_key=routing_key)
+
+        yield setupQueue()
+        self.amqpBroker.queueSetupCallbacks.append(setupQueue)
 
         # Instanciate smpp client service manager
         serviceManager = SMPPClientService(c, self.config)
@@ -369,37 +374,42 @@ class SMPPClientManagerPB(pb.Avatar):
         # check jasmin.queues.test.test_amqp.PublishConsumeTestCase.test_simple_publish_consume_by_topic
         submit_sm_queue = 'submit.sm.%s' % connector['id']
         consumerTag = 'SMPPClientFactory-%s' % (connector['id'])
+        
+        @defer.inlineCallbacks
+        def setupQueue():
+            try:
+                # Using the same consumerTag will prevent getting multiple consumers on the same queue
+                # This can resolve the dark hole issue #234
 
-        try:
-            # Using the same consumerTag will prevent getting multiple consumers on the same queue
-            # This can resolve the dark hole issue #234
+                # Stop the queue consumer if any
+                if connector['consumer_tag'] is not None:
+                    self.log.debug('Stopping submit_sm_q consumer in connector [%s]', cid)
+                    yield self.amqpBroker.chan.basic_cancel(consumer_tag=connector['consumer_tag'])
 
-            # Stop the queue consumer if any
-            if connector['consumer_tag'] is not None:
-                self.log.debug('Stopping submit_sm_q consumer in connector [%s]', cid)
-                yield self.amqpBroker.chan.basic_cancel(consumer_tag=connector['consumer_tag'])
+                # Start a new consumer
+                yield self.amqpBroker.chan.basic_consume(queue=submit_sm_queue,
+                                                        no_ack=False, consumer_tag=consumerTag)
+            except Exception as e:
+                self.log.error('Error consuming from queue %s: %s', submit_sm_queue, e)
+                defer.returnValue(False)
 
-            # Start a new consumer
-            yield self.amqpBroker.chan.basic_consume(queue=submit_sm_queue,
-                                                     no_ack=False, consumer_tag=consumerTag)
-        except Exception as e:
-            self.log.error('Error consuming from queue %s: %s', submit_sm_queue, e)
-            defer.returnValue(False)
+            submit_sm_q = yield self.amqpBroker.client.queue(consumerTag)
+            self.log.info('%s is consuming from queue: %s', consumerTag, submit_sm_queue)
 
-        submit_sm_q = yield self.amqpBroker.client.queue(consumerTag)
-        self.log.info('%s is consuming from queue: %s', consumerTag, submit_sm_queue)
+            # Set callbacks for every consumed message from submit_sm_queue queue
+            d = submit_sm_q.get()
+            d.addCallback(connector['sm_listener'].submit_sm_callback).addErrback(
+                connector['sm_listener'].submit_sm_errback)
 
-        # Set callbacks for every consumed message from submit_sm_queue queue
-        d = submit_sm_q.get()
-        d.addCallback(connector['sm_listener'].submit_sm_callback).addErrback(
-            connector['sm_listener'].submit_sm_errback)
+            self.log.info('Started connector [%s]', cid)
 
-        self.log.info('Started connector [%s]', cid)
-
-        # Set connector data
-        connector['sm_listener'].setSubmitSmQ(submit_sm_q)
-        connector['consumer_tag'] = consumerTag
-        connector['submit_sm_q'] = submit_sm_q
+            # Set connector data
+            connector['sm_listener'].setSubmitSmQ(submit_sm_q)
+            connector['consumer_tag'] = consumerTag
+            connector['submit_sm_q'] = submit_sm_q
+            
+        yield setupQueue()
+        self.amqpBroker.queueSetupCallbacks.append(setupQueue)
 
         # Set persistance state to False (pending for persistance)
         self.persisted = False

--- a/jasmin/managers/dlr.py
+++ b/jasmin/managers/dlr.py
@@ -65,11 +65,16 @@ class DLRLookup:
         consumerTag = 'DLRLookup-%s' % self.pid
         queueName = 'DLRLookup-%s' % self.pid  # A local queue to this object
         routing_key = 'dlr.*'
-        yield self.amqpBroker.chan.exchange_declare(exchange='messaging', type='topic')
-        yield self.amqpBroker.named_queue_declare(queue=queueName)
-        yield self.amqpBroker.chan.queue_bind(queue=queueName, exchange="messaging", routing_key=routing_key)
-        yield self.amqpBroker.chan.basic_consume(queue=queueName, no_ack=False, consumer_tag=consumerTag)
-        self.amqpBroker.client.queue(consumerTag).addCallback(self.setup_callbacks)
+        @defer.inlineCallbacks
+        def setupQueue():
+            yield self.amqpBroker.chan.exchange_declare(exchange='messaging', type='topic')
+            yield self.amqpBroker.named_queue_declare(queue=queueName, durable=True)
+            yield self.amqpBroker.chan.queue_bind(queue=queueName, exchange="messaging", routing_key=routing_key)
+            yield self.amqpBroker.chan.basic_consume(queue=queueName, no_ack=False, consumer_tag=consumerTag)
+            self.amqpBroker.client.queue(consumerTag).addCallback(self.setup_callbacks)
+            
+        yield setupQueue()
+        self.amqpBroker.queueSetupCallbacks.append(setupQueue)
 
     @defer.inlineCallbacks
     def rejectAndRequeueMessage(self, message, delay=True):

--- a/jasmin/queues/factory.py
+++ b/jasmin/queues/factory.py
@@ -50,8 +50,7 @@ class AmqpFactory(ClientFactory):
         self.connectionRetry = True
 
         self.exitDeferred = defer.Deferred()
-        if self.channelReady is None:
-            self.channelReady = defer.Deferred()
+        self.channelReady = defer.Deferred()
 
         try:
             # Check if connectDeferred is already set

--- a/jasmin/queues/factory.py
+++ b/jasmin/queues/factory.py
@@ -19,6 +19,7 @@ class AmqpFactory(ClientFactory):
         self.connected = False
         self.config = config
         self.channelReady = None
+        self.queueSetupCallbacks = []
 
         self.delegate = TwistedDelegate()
 
@@ -171,6 +172,7 @@ class AmqpFactory(ClientFactory):
         d.addCallback(self._channel_open)
         d.addErrback(self._channel_open_failed)
 
+    @defer.inlineCallbacks
     def _channel_open(self, arg):
         """Called when the channel is open."""
         self.log.info("The channel is open")
@@ -178,6 +180,9 @@ class AmqpFactory(ClientFactory):
         # Flag that the connection is open.
         self.connected = True
         self.channelReady.callback(self)
+        
+        for queueSetupCallback in self.queueSetupCallbacks:
+            yield queueSetupCallback()
 
     def _channel_open_failed(self, error):
         self.log.error("Channel open failed: %s", error)

--- a/jasmin/routing/router.py
+++ b/jasmin/routing/router.py
@@ -82,31 +82,36 @@ class RouterPB(pb.Avatar):
             yield self.amqpBroker.channelReady
             self.log.info("AMQP Broker channel is ready now, let's go !")
 
-        # Subscribe to deliver.sm.* queues
-        yield self.amqpBroker.chan.exchange_declare(exchange='messaging', type='topic')
-        consumerTag = 'RouterPB-delivers'
-        routingKey = 'deliver.sm.*'
-        queueName = 'RouterPB_deliver_sm_all'  # A local queue to RouterPB
-        yield self.amqpBroker.named_queue_declare(queue=queueName)
-        yield self.amqpBroker.chan.queue_bind(queue=queueName, exchange="messaging", routing_key=routingKey)
-        yield self.amqpBroker.chan.basic_consume(queue=queueName, no_ack=False, consumer_tag=consumerTag)
-        self.deliver_sm_q = yield self.amqpBroker.client.queue(consumerTag)
-        self.deliver_sm_q.get().addCallback(self.deliver_sm_callback).addErrback(self.deliver_sm_errback)
-        self.log.info('RouterPB is consuming from routing key: %s', routingKey)
+        @defer.inlineCallbacks
+        def setupQueue():
+            # Subscribe to deliver.sm.* queues
+            yield self.amqpBroker.chan.exchange_declare(exchange='messaging', type='topic')
+            consumerTag = 'RouterPB-delivers'
+            routingKey = 'deliver.sm.*'
+            queueName = 'RouterPB_deliver_sm_all'  # A local queue to RouterPB
+            yield self.amqpBroker.named_queue_declare(queue=queueName, durable=True)
+            yield self.amqpBroker.chan.queue_bind(queue=queueName, exchange="messaging", routing_key=routingKey)
+            yield self.amqpBroker.chan.basic_consume(queue=queueName, no_ack=False, consumer_tag=consumerTag)
+            self.deliver_sm_q = yield self.amqpBroker.client.queue(consumerTag)
+            self.deliver_sm_q.get().addCallback(self.deliver_sm_callback).addErrback(self.deliver_sm_errback)
+            self.log.info('RouterPB is consuming from routing key: %s', routingKey)
 
-        # Subscribe to bill_request.submit_sm_resp.* queues
-        yield self.amqpBroker.chan.exchange_declare(exchange='billing', type='topic')
-        consumerTag = 'RouterPB-billrequests'
-        routingKey = 'bill_request.submit_sm_resp.*'
-        queueName = 'RouterPB_bill_request_submit_sm_resp_all'  # A local queue to RouterPB
-        yield self.amqpBroker.named_queue_declare(queue=queueName)
-        yield self.amqpBroker.chan.queue_bind(queue=queueName, exchange="billing", routing_key=routingKey)
-        yield self.amqpBroker.chan.basic_consume(queue=queueName, no_ack=False, consumer_tag=consumerTag)
-        self.bill_request_submit_sm_resp_q = yield self.amqpBroker.client.queue(consumerTag)
-        self.bill_request_submit_sm_resp_q.get().addCallback(
-            self.bill_request_submit_sm_resp_callback).addErrback(
-            self.bill_request_submit_sm_resp_errback)
-        self.log.info('RouterPB is consuming from routing key: %s', routingKey)
+            # Subscribe to bill_request.submit_sm_resp.* queues
+            yield self.amqpBroker.chan.exchange_declare(exchange='billing', type='topic')
+            consumerTag = 'RouterPB-billrequests'
+            routingKey = 'bill_request.submit_sm_resp.*'
+            queueName = 'RouterPB_bill_request_submit_sm_resp_all'  # A local queue to RouterPB
+            yield self.amqpBroker.named_queue_declare(queue=queueName, durable=True)
+            yield self.amqpBroker.chan.queue_bind(queue=queueName, exchange="billing", routing_key=routingKey)
+            yield self.amqpBroker.chan.basic_consume(queue=queueName, no_ack=False, consumer_tag=consumerTag)
+            self.bill_request_submit_sm_resp_q = yield self.amqpBroker.client.queue(consumerTag)
+            self.bill_request_submit_sm_resp_q.get().addCallback(
+                self.bill_request_submit_sm_resp_callback).addErrback(
+                self.bill_request_submit_sm_resp_errback)
+            self.log.info('RouterPB is consuming from routing key: %s', routingKey)
+            
+        yield setupQueue()
+        self.amqpBroker.queueSetupCallbacks.append(setupQueue)
 
     @defer.inlineCallbacks
     def rejectMessage(self, message):

--- a/jasmin/routing/throwers.py
+++ b/jasmin/routing/throwers.py
@@ -165,19 +165,24 @@ class Thrower(Service):
             yield self.amqpBroker.channelReady
             self.log.info("AMQP Broker channel is ready now, let's go !")
 
-        # Declare exchange, queue and start consuming to self.callback
-        yield self.amqpBroker.chan.exchange_declare(exchange=self.exchangeName,
-                                                    type='topic')
-        yield self.amqpBroker.named_queue_declare(queue=self.queueName)
-        yield self.amqpBroker.chan.queue_bind(queue=self.queueName,
-                                              exchange=self.exchangeName,
-                                              routing_key=self.routingKey)
-        yield self.amqpBroker.chan.basic_consume(queue=self.queueName,
-                                                 no_ack=False,
-                                                 consumer_tag=self.consumerTag)
-        self.thrower_q = yield self.amqpBroker.client.queue(self.consumerTag)
-        self.thrower_q.get().addCallback(self.callback).addErrback(self.errback)
-        self.log.info('Consuming from routing key: %s', self.routingKey)
+        @defer.inlineCallbacks
+        def setupQueue():
+            # Declare exchange, queue and start consuming to self.callback
+            yield self.amqpBroker.chan.exchange_declare(exchange=self.exchangeName,
+                                                        type='topic')
+            yield self.amqpBroker.named_queue_declare(queue=self.queueName, durable=True)
+            yield self.amqpBroker.chan.queue_bind(queue=self.queueName,
+                                                exchange=self.exchangeName,
+                                                routing_key=self.routingKey)
+            yield self.amqpBroker.chan.basic_consume(queue=self.queueName,
+                                                    no_ack=False,
+                                                    consumer_tag=self.consumerTag)
+            self.thrower_q = yield self.amqpBroker.client.queue(self.consumerTag)
+            self.thrower_q.get().addCallback(self.callback).addErrback(self.errback)
+            self.log.info('Consuming from routing key: %s', self.routingKey)
+        
+        yield setupQueue()
+        self.amqpBroker.queueSetupCallbacks.append(setupQueue)
 
     @defer.inlineCallbacks
     def rejectAndRequeueMessage(self, message, delay=True):


### PR DESCRIPTION
Fix #1162
Fix #1022

### Description
The PR fixes the issue of Jasmin not able to reconnect to RabbitMQ after losing connection, and declares queues as durable to not loose any queued messages.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed