### PR TITLE
Fix long-submit timeout errback for multipart SubmitSm transactions

### DIFF
--- a/jasmin/protocols/smpp/protocol.py
+++ b/jasmin/protocols/smpp/protocol.py
@@ -169,6 +169,11 @@ class SMPPClientProtocol(twistedSMPPClientProtocol):
             # Do errback
             txn.ackDeferred.errback(err)
 
+    def onLongSubmitSmTransactionTimeout(self, reqPDU, timeout):
+        txn = self.closeLongSubmitSmTransaction(reqPDU.LongSubmitSm['msg_ref_num'])
+        errMsg = 'Long submit_sm transaction timed out after %s secs: %s' % (timeout, reqPDU)
+        txn.ackDeferred.errback(SMPPRequestTimoutError(errMsg))
+
     def startLongSubmitSmTransaction(self, reqPDU, timeout):
         if reqPDU.LongSubmitSm['msg_ref_num'] in self.longSubmitSmTxns:
             self.log.error(
@@ -181,7 +186,7 @@ class SMPPClientProtocol(twistedSMPPClientProtocol):
         # Create callback deferred
         ackDeferred = defer.Deferred()
         # Create response timer
-        timer = reactor.callLater(timeout, self.onResponseTimeout, reqPDU, timeout)
+        timer = reactor.callLater(timeout, self.onLongSubmitSmTransactionTimeout, reqPDU, timeout)
         # Save transaction
         self.longSubmitSmTxns[reqPDU.LongSubmitSm['msg_ref_num']] = {
             'txn': SMPPOutboundTxn(reqPDU, timer, ackDeferred),


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Fix # <!-- Issue # here -->

### Description
Problem: In multipart SubmitSm (SAR) flows, the long-submit transaction Deferred returned by sendDataRequest() never reaches errback or callback when a timeout occurs, causing the consumer to stall and RabbitMQ unacked messages to accumulate.

Cause: The code called startLongSubmitSmTransaction() to create a Deferred, but the timeout handler erroneously either did not errback the same Deferred or used a bare Exception instead of Failure, so upstream code never resumed.

Fix:

Ensure startLongSubmitSmTransaction() returns the exact same Deferred stored in state.

Timeout handler cancels per-part timers and calls d.errback(Failure(SMPPRequestTimoutError(...))).

Guard callback/errback with if not d.called:.

Not yet Added unit test that simulates no responses for multipart and asserts Deferred fails with SMPPRequestTimoutError.

Impact: This fixes the message-consumer stall issue and ensures multipart flows either succeed or fail in finite time.

Please review and let me know if you’d like additional adjustments (e.g., config setting for timeout behaviour).

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
